### PR TITLE
Improved video code.

### DIFF
--- a/FIRM_W25/SRC_W25/VIDEO.PAS
+++ b/FIRM_W25/SRC_W25/VIDEO.PAS
@@ -31,6 +31,7 @@ interface
 		TVideoLine = string[80];
 		TVideoWriteTextProc = procedure(x, y, color: byte; text: TVideoLine);
 	const
+		PORT_CGA_MODE = $03D8;
 		PORT_CGA_PALETTE = $03D9;
 	var
 		VideoWriteText: TVideoWriteTextProc;
@@ -40,6 +41,9 @@ interface
 		VideoTextSegment: word;
 		VideoTextPointer: pointer;
 		VideoCursorVisible: boolean;
+		VideoEGAInstalled: boolean;
+		VideoMDAInstalled: boolean;
+		VideoUseFastPath: boolean;
 	function VideoConfigure: boolean;
 	procedure VideoInstall(columns, borderColor: integer);
 	procedure VideoUninstall;
@@ -51,7 +55,7 @@ interface
 	procedure SetAccKeys;
 
 implementation
-uses Crt, Dos, Acckeys;
+uses Crt, Dos, AccKeys;
 
 {$F+}
 
@@ -59,6 +63,7 @@ procedure SetAccKeys;
 	var
 		regs: Registers;
 	begin
+		if not VideoEGAInstalled then exit;
 		regs.ax := $1110;
 		regs.bh := $0E;                           (* bytes per character *)
 		regs.bl := 0;                             (* load to block 0 *)
@@ -73,6 +78,13 @@ procedure SetBlink(blinkState: boolean);
 	var
 		regs: Registers;
 	begin
+		{ CGA cards }
+		if blinkState then
+			Port[PORT_CGA_MODE] := Port[PORT_CGA_MODE] or $20
+		else
+			Port[PORT_CGA_MODE] := Port[PORT_CGA_MODE] and $DF;
+
+		{ EGA/VGA cards }
 		regs.ax := $1003;
 		if blinkState then
 			regs.bx := $0001
@@ -81,125 +93,77 @@ procedure SetBlink(blinkState: boolean);
 		Intr($10, regs);
 	end;
 
-procedure VideoWriteTextCO80(x, y, color: byte; text: TVideoLine);
+procedure VideoWriteTextCGA(x, y, color: byte; text: TVideoLine);
 	begin
 		inline(
-			$1E/                 { PUSH DS }
-			$1E/                 { PUSH DS }
+			$8B/$06/VideoTextSegment/{ MOV AX, VideoTextSegment }
+			$8E/$C0/             { MOV ES, AX }
 			$8A/$86/y/           { MOV AL, byte ptr [BP + y] }
-			$B3/$50/             { MOV BL, 0x50 }
-			$F6/$E3/             { MUL BL }
-			$2B/$DB/             { SUB BX, BX }
-			$8A/$9E/x/           { MOV BL, byte ptr [BP + x] }
-			$03/$C3/             { ADD AX, BX }
-			$03/$C0/             { ADD AX, AX }
+			$F6/$26/VideoColumns/{ MUL VideoColumns }
+			$31/$C9/             { XOR CX, CX }
+			$89/$CE/             { MOV SI, CX }
+			$8A/$8E/x/           { MOV CL, byte ptr [BP + x] }
+			$01/$C8/             { ADD AX, CX }
+			$D1/$E0/             { SHL AX, 1 }
 			$8B/$F8/             { MOV DI, AX }
-			$BE/$00/$00/         { MOV SI, 0x0 }
 			$8A/$BE/color/       { MOV BH, byte ptr [BP + color] }
 			$8A/$8E/text/        { MOV CL, byte ptr [BP + text] }
-			$22/$C9/             { AND CL, CL }
-			$74/$3E/             { JZ label_0084 }
-			$2B/$C0/             { SUB AX, AX }
-			$8E/$D8/             { MOV DS, AX }
-			$A0/$0449/           { MOV AL, [BiosBDA.VideoMode] }
-			$1F/                 { POP DS }
-			$2C/$07/             { SUB AL, 0x7 }
-			$74/$22/             { JZ label_0074 }
-			$BA/$B800/           { MOV DX, 0xB800 }
-			$8E/$DA/             { MOV DS, DX }
 			$BA/$03DA/           { MOV DX, 0x03DA }
-			{ label_005a }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			{ label_005f }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$75/$FB/             { JNZ label_005f }
+			$22/$C9/             { AND CL, CL }
+			$74/$1A/             { JZ finish }
 			$FA/                 { CLI }
-			{ label_0065 }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$74/$FB/             { JZ label_0065 }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$EA/             { LOOP label_005a }
-			$2A/$C0/             { SUB AL, AL }
-			$74/$10/             { JZ label_0084 }
-			{ label_0074 }
-			$BA/$B000/           { MOV DX, 0xB000 }
-			$8E/$DA/             { MOV DS, DX }
-			{ label_0079 }
+		{ next_char: }
 			$46/                 { INC SI }
 			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$F5/             { LOOP label_0079 }
-			{ label_0084 }
-			$1F/                 { POP DS }
+		{ cga_snow: }
+			$EC/                 { IN AL, DX }
+			$A8/$08/             { TEST AL, 8 }
+			$75/$09/             { JNZ write_char }
+			$D0/$E8/             { SHR AL, 1 }
+			$72/$F7/             { JC cga_snow }
+		{ cga_snow2: }
+			$EC/                 { IN AL, DX }
+			$D0/$E8/             { SHR AL, 1 }
+			$73/$FB/             { JNC cga_snow2 }
+		{ write_char: }
+			$89/$D8/             { MOV AX, BX }
+			$AB/                 { STOSW }
+			$E2/$E8/             { LOOP next_char }
 			$FB                  { STI }
+		{ finish: }
 		);
 	end;
 
-procedure VideoWriteTextCO40(x, y, color: byte; text: TVideoLine);
+procedure VideoWriteTextFast(x, y, color: byte; text: TVideoLine);
 	begin
 		inline(
-			$1E/                 { PUSH DS }
-			$1E/                 { PUSH DS }
+			$8B/$06/VideoTextSegment/{ MOV AX, VideoTextSegment }
+			$8E/$C0/             { MOV ES, AX }
 			$8A/$86/y/           { MOV AL, byte ptr [BP + y] }
-			$B3/$28/             { MOV BL, 0x28 }
-			$F6/$E3/             { MUL BL }
-			$2B/$DB/             { SUB BX, BX }
-			$8A/$9E/x/           { MOV BL, byte ptr [BP + x] }
-			$03/$C3/             { ADD AX, BX }
-			$03/$C0/             { ADD AX, AX }
+			$F6/$26/VideoColumns/{ MUL VideoColumns }
+			$31/$C9/             { XOR CX, CX }
+			$89/$CE/             { MOV SI, CX }
+			$8A/$8E/x/           { MOV CL, byte ptr [BP + x] }
+			$01/$C8/             { ADD AX, CX }
+			$D1/$E0/             { SHL AX, 1 }
 			$8B/$F8/             { MOV DI, AX }
-			$BE/$00/$00/         { MOV SI, 0x0 }
-			$8A/$BE/color/       { MOV BH, byte ptr [BP + color] }
+			$8A/$A6/color/       { MOV AH, byte ptr [BP + color] }
 			$8A/$8E/text/        { MOV CL, byte ptr [BP + text] }
 			$22/$C9/             { AND CL, CL }
-			$74/$3E/             { JZ label_0084 }
-			$2B/$C0/             { SUB AX, AX }
-			$8E/$D8/             { MOV DS, AX }
-			$A0/$0449/           { MOV AL, [BiosBDA.VideoMode] }
-			$1F/                 { POP DS }
-			$2C/$07/             { SUB AL, 0x7 }
-			$74/$22/             { JZ label_0074 }
-			$BA/$B800/           { MOV DX, 0xB800 }
-			$8E/$DA/             { MOV DS, DX }
-			$BA/$03DA/           { MOV DX, 0x03DA }
-			{ label_005a }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			{ label_005f }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$75/$FB/             { JNZ label_005f }
+			$74/$0A/             { JZ finish }
 			$FA/                 { CLI }
-			{ label_0065 }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$74/$FB/             { JZ label_0065 }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$EA/             { LOOP label_005a }
-			$2A/$C0/             { SUB AL, AL }
-			$74/$10/             { JZ label_0084 }
-			{ label_0074 }
-			$BA/$B000/           { MOV DX, 0xB000 }
-			$8E/$DA/             { MOV DS, DX }
-			{ label_0079 }
+		{ next_char: }
 			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$F5/             { LOOP label_0079 }
-			{ label_0084 }
-			$1F/                 { POP DS }
+			$8A/$82/text/        { MOV AL, byte ptr [BP + SI + text] }
+			$AB/                 { STOSW }
+			$E2/$F8/             { LOOP next_char }
 			$FB                  { STI }
+		{ finish: }
 		);
 	end;
 
-procedure VideoWriteTextBW80(x, y, color: byte; text: TVideoLine);
+
+function ColorToBW(color: byte): byte;
 	begin
 		if (color and $08) = $08 then begin
 			if (color and $F0) = 0 then
@@ -212,131 +176,17 @@ procedure VideoWriteTextBW80(x, y, color: byte; text: TVideoLine);
 			else
 				color := $70;
 		end;
-		inline(
-			$1E/                 { PUSH DS }
-			$1E/                 { PUSH DS }
-			$8A/$86/y/           { MOV AL, byte ptr [BP + y] }
-			$B3/$50/             { MOV BL, 0x50 }
-			$F6/$E3/             { MUL BL }
-			$2B/$DB/             { SUB BX, BX }
-			$8A/$9E/x/           { MOV BL, byte ptr [BP + x] }
-			$03/$C3/             { ADD AX, BX }
-			$03/$C0/             { ADD AX, AX }
-			$8B/$F8/             { MOV DI, AX }
-			$BE/$00/$00/         { MOV SI, 0x0 }
-			$8A/$BE/color/       { MOV BH, byte ptr [BP + color] }
-			$8A/$8E/text/        { MOV CL, byte ptr [BP + text] }
-			$22/$C9/             { AND CL, CL }
-			$74/$3E/             { JZ label_0084 }
-			$2B/$C0/             { SUB AX, AX }
-			$8E/$D8/             { MOV DS, AX }
-			$A0/$0449/           { MOV AL, [BiosBDA.VideoMode] }
-			$1F/                 { POP DS }
-			$2C/$07/             { SUB AL, 0x7 }
-			$74/$22/             { JZ label_0074 }
-			$BA/$B800/           { MOV DX, 0xB800 }
-			$8E/$DA/             { MOV DS, DX }
-			$BA/$03DA/           { MOV DX, 0x03DA }
-			{ label_005a }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			{ label_005f }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$75/$FB/             { JNZ label_005f }
-			$FA/                 { CLI }
-			{ label_0065 }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$74/$FB/             { JZ label_0065 }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$EA/             { LOOP label_005a }
-			$2A/$C0/             { SUB AL, AL }
-			$74/$10/             { JZ label_0084 }
-			{ label_0074 }
-			$BA/$B000/           { MOV DX, 0xB000 }
-			$8E/$DA/             { MOV DS, DX }
-			{ label_0079 }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$F5/             { LOOP label_0079 }
-			{ label_0084 }
-			$1F/                 { POP DS }
-			$FB                  { STI }
-		);
+		ColorToBW := color;
 	end;
 
-procedure VideoWriteTextBW40(x, y, color: byte; text: TVideoLine);
+procedure VideoWriteTextCGABW(x, y, color: byte; text: TVideoLine);
 	begin
-		if (color and $08) = $08 then begin
-			if (color and $F0) = 0 then
-				color := $0F
-			else
-				color := $7F;
-		end else begin
-			if (color and $07) <> 0 then
-				color := $07
-			else
-				color := $70;
-		end;
-		inline(
-			$1E/                 { PUSH DS }
-			$1E/                 { PUSH DS }
-			$8A/$86/y/           { MOV AL, byte ptr [BP + y] }
-			$B3/$28/             { MOV BL, 0x28 }
-			$F6/$E3/             { MUL BL }
-			$2B/$DB/             { SUB BX, BX }
-			$8A/$9E/x/           { MOV BL, byte ptr [BP + x] }
-			$03/$C3/             { ADD AX, BX }
-			$03/$C0/             { ADD AX, AX }
-			$8B/$F8/             { MOV DI, AX }
-			$BE/$00/$00/         { MOV SI, 0x0 }
-			$8A/$BE/color/       { MOV BH, byte ptr [BP + color] }
-			$8A/$8E/text/        { MOV CL, byte ptr [BP + text] }
-			$22/$C9/             { AND CL, CL }
-			$74/$3E/             { JZ label_0084 }
-			$2B/$C0/             { SUB AX, AX }
-			$8E/$D8/             { MOV DS, AX }
-			$A0/$0449/           { MOV AL, [BiosBDA.VideoMode] }
-			$1F/                 { POP DS }
-			$2C/$07/             { SUB AL, 0x7 }
-			$74/$22/             { JZ label_0074 }
-			$BA/$B800/           { MOV DX, 0xB800 }
-			$8E/$DA/             { MOV DS, DX }
-			$BA/$03DA/           { MOV DX, 0x03DA }
-			{ label_005a }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			{ label_005f }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$75/$FB/             { JNZ label_005f }
-			$FA/                 { CLI }
-			{ label_0065 }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$74/$FB/             { JZ label_0065 }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$EA/             { LOOP label_005a }
-			$2A/$C0/             { SUB AL, AL }
-			$74/$10/             { JZ label_0084 }
-			{ label_0074 }
-			$BA/$B000/           { MOV DX, 0xB000 }
-			$8E/$DA/             { MOV DS, DX }
-			{ label_0079 }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$F5/             { LOOP label_0079 }
-			{ label_0084 }
-			$1F/                 { POP DS }
-			$FB                  { STI }
-		);
+		VideoWriteTextCGA(x, y, ColorToBW(color), text);
+	end;
+
+procedure VideoWriteTextFastBW(x, y, color: byte; text: TVideoLine);
+	begin
+		VideoWriteTextFast(x, y, ColorToBW(color), text);
 	end;
 
 {$F-}
@@ -347,7 +197,7 @@ function VideoConfigure: boolean;
 	begin
 		charTyped := ' ';
 		if LastMode = 7 then begin
-			VideoWriteText := VideoWriteTextBW80;
+			VideoWriteText := VideoWriteTextFastBW;
 			VideoMonochrome := true;
 		end else begin
 			Writeln;
@@ -369,40 +219,56 @@ procedure VideoInstall(columns, borderColor: integer);
 	var
 		regs: Registers;
 	begin
-		regs.AX := $1201;
-		regs.BL := $30;
+		regs.AH := $12;
+		regs.BX := $FF10;
 		Intr($10, regs);
+		VideoEGAInstalled := regs.BH <> $FF;
+		VideoMDAInstalled := LastMode = 7;
+		VideoUseFastPath := VideoUseFastPath or VideoEGAInstalled or VideoMDAInstalled;
+
+		if VideoEGAInstalled then begin
+			regs.AX := $1201;
+			regs.BL := $30;
+			Intr($10, regs);
+		end;
 
 		if not VideoMonochrome then
 			TextBackground(borderColor);
 
 		VideoColumns := columns;
 		if VideoMonochrome then begin
-			if LastMode in [0, 1, 2, 3] then begin
+			if VideoUseFastPath then
+				VideoWriteText := VideoWriteTextFastBW
+			else
+				VideoWriteText := VideoWriteTextCGABW;
+
+			if (LastMode >= 0) and (LastMode <= 3) then begin
 				if columns = 80 then begin
 					TextMode(BW80);
-					VideoWriteText := VideoWriteTextBW80;
 				end else begin
 					TextMode(BW40);
-					VideoWriteText := VideoWriteTextBW40;
 				end;
 			end else begin
-				VideoWriteText := VideoWriteTextBW80;
 				TextMode(7);
 				VideoColumns := 80;
 			end;
 		end else begin
+			if VideoUseFastPath then
+				VideoWriteText := VideoWriteTextFast
+			else
+				VideoWriteText := VideoWriteTextCGA;
+
 			if VideoColumns = 80 then begin
 				TextMode(CO80);
-				VideoWriteText := VideoWriteTextCO80;
 			end else begin
 				TextMode(CO40);
-				VideoWriteText := VideoWriteTextCO40;
 			end;
-			if not VideoMonochrome then
-				TextBackground(borderColor);
-			ClrScr;
+
+			TextBackground(borderColor);
 		end;
+
+		ClrScr;
+
 		if not VideoCursorVisible then
 			VideoHideCursor;
 		VideoSetBorderColor(borderColor);
@@ -412,9 +278,12 @@ procedure VideoUninstall;
 	var
 		regs: Registers;
 	begin
-		regs.AX := $1201;
-		regs.BL := $30;
-		Intr($10, regs);
+		if VideoEGAInstalled then begin
+			regs.AX := $1201;
+			regs.BL := $30;
+			Intr($10, regs);
+		end;
+
 		TextBackground(0);
 		VideoColumns := 80;
 		if VideoMonochrome then
@@ -457,7 +326,8 @@ procedure VideoMove(x, y, chars: integer; data: pointer; toVideo: boolean);
 		offset: integer;
 	begin
 		offset := (y * VideoColumns + x) * 2;
-		VideoWriteTextCO80(0, 0, 0, '');
+		if not VideoUseFastPath then
+			VideoWriteTextCGA(0, 0, 0, '');
 		if toVideo then
 			Move(data^, Ptr(VideoTextSegment, offset)^, chars * 2)
 		else
@@ -468,7 +338,7 @@ procedure VideoMove(x, y, chars: integer; data: pointer; toVideo: boolean);
 begin
 	VideoBorderColor := 0;
 	VideoColumns := 80;
-	VideoWriteText := VideoWriteTextBW80;
+	VideoWriteText := VideoWriteTextFastBW;
 	if LastMode = 7 then begin
 		VideoTextSegment := $B000;
 		VideoMonochrome := true;
@@ -478,4 +348,5 @@ begin
 	end;
 	VideoTextPointer := Ptr(VideoTextSegment, $0000);
 	VideoCursorVisible := true;
+	VideoUseFastPath := false;
 end.

--- a/SOFT_W25/SRC_W25/VIDEO.PAS
+++ b/SOFT_W25/SRC_W25/VIDEO.PAS
@@ -31,6 +31,7 @@ interface
 		TVideoLine = string[80];
 		TVideoWriteTextProc = procedure(x, y, color: byte; text: TVideoLine);
 	const
+		PORT_CGA_MODE = $03D8;
 		PORT_CGA_PALETTE = $03D9;
 	var
 		VideoWriteText: TVideoWriteTextProc;
@@ -40,6 +41,9 @@ interface
 		VideoTextSegment: word;
 		VideoTextPointer: pointer;
 		VideoCursorVisible: boolean;
+		VideoEGAInstalled: boolean;
+		VideoMDAInstalled: boolean;
+		VideoUseFastPath: boolean;
 	function VideoConfigure: boolean;
 	procedure VideoInstall(columns, borderColor: integer);
 	procedure VideoUninstall;
@@ -59,6 +63,7 @@ procedure SetAccKeys;
 	var
 		regs: Registers;
 	begin
+		if not VideoEGAInstalled then exit;
 		regs.ax := $1110;
 		regs.bh := $0E;                           (* bytes per character *)
 		regs.bl := 0;                             (* load to block 0 *)
@@ -73,6 +78,13 @@ procedure SetBlink(blinkState: boolean);
 	var
 		regs: Registers;
 	begin
+		{ CGA cards }
+		if blinkState then
+			Port[PORT_CGA_MODE] := Port[PORT_CGA_MODE] or $20
+		else
+			Port[PORT_CGA_MODE] := Port[PORT_CGA_MODE] and $DF;
+
+		{ EGA/VGA cards }
 		regs.ax := $1003;
 		if blinkState then
 			regs.bx := $0001
@@ -81,125 +93,77 @@ procedure SetBlink(blinkState: boolean);
 		Intr($10, regs);
 	end;
 
-procedure VideoWriteTextCO80(x, y, color: byte; text: TVideoLine);
+procedure VideoWriteTextCGA(x, y, color: byte; text: TVideoLine);
 	begin
 		inline(
-			$1E/                 { PUSH DS }
-			$1E/                 { PUSH DS }
+			$8B/$06/VideoTextSegment/{ MOV AX, VideoTextSegment }
+			$8E/$C0/             { MOV ES, AX }
 			$8A/$86/y/           { MOV AL, byte ptr [BP + y] }
-			$B3/$50/             { MOV BL, 0x50 }
-			$F6/$E3/             { MUL BL }
-			$2B/$DB/             { SUB BX, BX }
-			$8A/$9E/x/           { MOV BL, byte ptr [BP + x] }
-			$03/$C3/             { ADD AX, BX }
-			$03/$C0/             { ADD AX, AX }
+			$F6/$26/VideoColumns/{ MUL VideoColumns }
+			$31/$C9/             { XOR CX, CX }
+			$89/$CE/             { MOV SI, CX }
+			$8A/$8E/x/           { MOV CL, byte ptr [BP + x] }
+			$01/$C8/             { ADD AX, CX }
+			$D1/$E0/             { SHL AX, 1 }
 			$8B/$F8/             { MOV DI, AX }
-			$BE/$00/$00/         { MOV SI, 0x0 }
 			$8A/$BE/color/       { MOV BH, byte ptr [BP + color] }
 			$8A/$8E/text/        { MOV CL, byte ptr [BP + text] }
-			$22/$C9/             { AND CL, CL }
-			$74/$3E/             { JZ label_0084 }
-			$2B/$C0/             { SUB AX, AX }
-			$8E/$D8/             { MOV DS, AX }
-			$A0/$0449/           { MOV AL, [BiosBDA.VideoMode] }
-			$1F/                 { POP DS }
-			$2C/$07/             { SUB AL, 0x7 }
-			$74/$22/             { JZ label_0074 }
-			$BA/$B800/           { MOV DX, 0xB800 }
-			$8E/$DA/             { MOV DS, DX }
 			$BA/$03DA/           { MOV DX, 0x03DA }
-			{ label_005a }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			{ label_005f }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$75/$FB/             { JNZ label_005f }
+			$22/$C9/             { AND CL, CL }
+			$74/$1A/             { JZ finish }
 			$FA/                 { CLI }
-			{ label_0065 }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$74/$FB/             { JZ label_0065 }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$EA/             { LOOP label_005a }
-			$2A/$C0/             { SUB AL, AL }
-			$74/$10/             { JZ label_0084 }
-			{ label_0074 }
-			$BA/$B000/           { MOV DX, 0xB000 }
-			$8E/$DA/             { MOV DS, DX }
-			{ label_0079 }
+		{ next_char: }
 			$46/                 { INC SI }
 			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$F5/             { LOOP label_0079 }
-			{ label_0084 }
-			$1F/                 { POP DS }
+		{ cga_snow: }
+			$EC/                 { IN AL, DX }
+			$A8/$08/             { TEST AL, 8 }
+			$75/$09/             { JNZ write_char }
+			$D0/$E8/             { SHR AL, 1 }
+			$72/$F7/             { JC cga_snow }
+		{ cga_snow2: }
+			$EC/                 { IN AL, DX }
+			$D0/$E8/             { SHR AL, 1 }
+			$73/$FB/             { JNC cga_snow2 }
+		{ write_char: }
+			$89/$D8/             { MOV AX, BX }
+			$AB/                 { STOSW }
+			$E2/$E8/             { LOOP next_char }
 			$FB                  { STI }
+		{ finish: }
 		);
 	end;
 
-procedure VideoWriteTextCO40(x, y, color: byte; text: TVideoLine);
+procedure VideoWriteTextFast(x, y, color: byte; text: TVideoLine);
 	begin
 		inline(
-			$1E/                 { PUSH DS }
-			$1E/                 { PUSH DS }
+			$8B/$06/VideoTextSegment/{ MOV AX, VideoTextSegment }
+			$8E/$C0/             { MOV ES, AX }
 			$8A/$86/y/           { MOV AL, byte ptr [BP + y] }
-			$B3/$28/             { MOV BL, 0x28 }
-			$F6/$E3/             { MUL BL }
-			$2B/$DB/             { SUB BX, BX }
-			$8A/$9E/x/           { MOV BL, byte ptr [BP + x] }
-			$03/$C3/             { ADD AX, BX }
-			$03/$C0/             { ADD AX, AX }
+			$F6/$26/VideoColumns/{ MUL VideoColumns }
+			$31/$C9/             { XOR CX, CX }
+			$89/$CE/             { MOV SI, CX }
+			$8A/$8E/x/           { MOV CL, byte ptr [BP + x] }
+			$01/$C8/             { ADD AX, CX }
+			$D1/$E0/             { SHL AX, 1 }
 			$8B/$F8/             { MOV DI, AX }
-			$BE/$00/$00/         { MOV SI, 0x0 }
-			$8A/$BE/color/       { MOV BH, byte ptr [BP + color] }
+			$8A/$A6/color/       { MOV AH, byte ptr [BP + color] }
 			$8A/$8E/text/        { MOV CL, byte ptr [BP + text] }
 			$22/$C9/             { AND CL, CL }
-			$74/$3E/             { JZ label_0084 }
-			$2B/$C0/             { SUB AX, AX }
-			$8E/$D8/             { MOV DS, AX }
-			$A0/$0449/           { MOV AL, [BiosBDA.VideoMode] }
-			$1F/                 { POP DS }
-			$2C/$07/             { SUB AL, 0x7 }
-			$74/$22/             { JZ label_0074 }
-			$BA/$B800/           { MOV DX, 0xB800 }
-			$8E/$DA/             { MOV DS, DX }
-			$BA/$03DA/           { MOV DX, 0x03DA }
-			{ label_005a }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			{ label_005f }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$75/$FB/             { JNZ label_005f }
+			$74/$0A/             { JZ finish }
 			$FA/                 { CLI }
-			{ label_0065 }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$74/$FB/             { JZ label_0065 }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$EA/             { LOOP label_005a }
-			$2A/$C0/             { SUB AL, AL }
-			$74/$10/             { JZ label_0084 }
-			{ label_0074 }
-			$BA/$B000/           { MOV DX, 0xB000 }
-			$8E/$DA/             { MOV DS, DX }
-			{ label_0079 }
+		{ next_char: }
 			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$F5/             { LOOP label_0079 }
-			{ label_0084 }
-			$1F/                 { POP DS }
+			$8A/$82/text/        { MOV AL, byte ptr [BP + SI + text] }
+			$AB/                 { STOSW }
+			$E2/$F8/             { LOOP next_char }
 			$FB                  { STI }
+		{ finish: }
 		);
 	end;
 
-procedure VideoWriteTextBW80(x, y, color: byte; text: TVideoLine);
+
+function ColorToBW(color: byte): byte;
 	begin
 		if (color and $08) = $08 then begin
 			if (color and $F0) = 0 then
@@ -212,131 +176,17 @@ procedure VideoWriteTextBW80(x, y, color: byte; text: TVideoLine);
 			else
 				color := $70;
 		end;
-		inline(
-			$1E/                 { PUSH DS }
-			$1E/                 { PUSH DS }
-			$8A/$86/y/           { MOV AL, byte ptr [BP + y] }
-			$B3/$50/             { MOV BL, 0x50 }
-			$F6/$E3/             { MUL BL }
-			$2B/$DB/             { SUB BX, BX }
-			$8A/$9E/x/           { MOV BL, byte ptr [BP + x] }
-			$03/$C3/             { ADD AX, BX }
-			$03/$C0/             { ADD AX, AX }
-			$8B/$F8/             { MOV DI, AX }
-			$BE/$00/$00/         { MOV SI, 0x0 }
-			$8A/$BE/color/       { MOV BH, byte ptr [BP + color] }
-			$8A/$8E/text/        { MOV CL, byte ptr [BP + text] }
-			$22/$C9/             { AND CL, CL }
-			$74/$3E/             { JZ label_0084 }
-			$2B/$C0/             { SUB AX, AX }
-			$8E/$D8/             { MOV DS, AX }
-			$A0/$0449/           { MOV AL, [BiosBDA.VideoMode] }
-			$1F/                 { POP DS }
-			$2C/$07/             { SUB AL, 0x7 }
-			$74/$22/             { JZ label_0074 }
-			$BA/$B800/           { MOV DX, 0xB800 }
-			$8E/$DA/             { MOV DS, DX }
-			$BA/$03DA/           { MOV DX, 0x03DA }
-			{ label_005a }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			{ label_005f }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$75/$FB/             { JNZ label_005f }
-			$FA/                 { CLI }
-			{ label_0065 }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$74/$FB/             { JZ label_0065 }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$EA/             { LOOP label_005a }
-			$2A/$C0/             { SUB AL, AL }
-			$74/$10/             { JZ label_0084 }
-			{ label_0074 }
-			$BA/$B000/           { MOV DX, 0xB000 }
-			$8E/$DA/             { MOV DS, DX }
-			{ label_0079 }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$F5/             { LOOP label_0079 }
-			{ label_0084 }
-			$1F/                 { POP DS }
-			$FB                  { STI }
-		);
+		ColorToBW := color;
 	end;
 
-procedure VideoWriteTextBW40(x, y, color: byte; text: TVideoLine);
+procedure VideoWriteTextCGABW(x, y, color: byte; text: TVideoLine);
 	begin
-		if (color and $08) = $08 then begin
-			if (color and $F0) = 0 then
-				color := $0F
-			else
-				color := $7F;
-		end else begin
-			if (color and $07) <> 0 then
-				color := $07
-			else
-				color := $70;
-		end;
-		inline(
-			$1E/                 { PUSH DS }
-			$1E/                 { PUSH DS }
-			$8A/$86/y/           { MOV AL, byte ptr [BP + y] }
-			$B3/$28/             { MOV BL, 0x28 }
-			$F6/$E3/             { MUL BL }
-			$2B/$DB/             { SUB BX, BX }
-			$8A/$9E/x/           { MOV BL, byte ptr [BP + x] }
-			$03/$C3/             { ADD AX, BX }
-			$03/$C0/             { ADD AX, AX }
-			$8B/$F8/             { MOV DI, AX }
-			$BE/$00/$00/         { MOV SI, 0x0 }
-			$8A/$BE/color/       { MOV BH, byte ptr [BP + color] }
-			$8A/$8E/text/        { MOV CL, byte ptr [BP + text] }
-			$22/$C9/             { AND CL, CL }
-			$74/$3E/             { JZ label_0084 }
-			$2B/$C0/             { SUB AX, AX }
-			$8E/$D8/             { MOV DS, AX }
-			$A0/$0449/           { MOV AL, [BiosBDA.VideoMode] }
-			$1F/                 { POP DS }
-			$2C/$07/             { SUB AL, 0x7 }
-			$74/$22/             { JZ label_0074 }
-			$BA/$B800/           { MOV DX, 0xB800 }
-			$8E/$DA/             { MOV DS, DX }
-			$BA/$03DA/           { MOV DX, 0x03DA }
-			{ label_005a }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			{ label_005f }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$75/$FB/             { JNZ label_005f }
-			$FA/                 { CLI }
-			{ label_0065 }
-			$EC/                 { IN AL, DX }
-			$A8/$01/             { TEST AL, 0x1 }
-			$74/$FB/             { JZ label_0065 }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$EA/             { LOOP label_005a }
-			$2A/$C0/             { SUB AL, AL }
-			$74/$10/             { JZ label_0084 }
-			{ label_0074 }
-			$BA/$B000/           { MOV DX, 0xB000 }
-			$8E/$DA/             { MOV DS, DX }
-			{ label_0079 }
-			$46/                 { INC SI }
-			$8A/$9A/text/        { MOV BL, byte ptr [BP + SI + text] }
-			$89/$1D/             { MOV word ptr [bufIdx], BX }
-			$47/$47/             { INC bufIdx x 2 }
-			$E2/$F5/             { LOOP label_0079 }
-			{ label_0084 }
-			$1F/                 { POP DS }
-			$FB                  { STI }
-		);
+		VideoWriteTextCGA(x, y, ColorToBW(color), text);
+	end;
+
+procedure VideoWriteTextFastBW(x, y, color: byte; text: TVideoLine);
+	begin
+		VideoWriteTextFast(x, y, ColorToBW(color), text);
 	end;
 
 {$F-}
@@ -347,7 +197,7 @@ function VideoConfigure: boolean;
 	begin
 		charTyped := ' ';
 		if LastMode = 7 then begin
-			VideoWriteText := VideoWriteTextBW80;
+			VideoWriteText := VideoWriteTextFastBW;
 			VideoMonochrome := true;
 		end else begin
 			Writeln;
@@ -369,40 +219,56 @@ procedure VideoInstall(columns, borderColor: integer);
 	var
 		regs: Registers;
 	begin
-		regs.AX := $1201;
-		regs.BL := $30;
+		regs.AH := $12;
+		regs.BX := $FF10;
 		Intr($10, regs);
+		VideoEGAInstalled := regs.BH <> $FF;
+		VideoMDAInstalled := LastMode = 7;
+		VideoUseFastPath := VideoUseFastPath or VideoEGAInstalled or VideoMDAInstalled;
+
+		if VideoEGAInstalled then begin
+			regs.AX := $1201;
+			regs.BL := $30;
+			Intr($10, regs);
+		end;
 
 		if not VideoMonochrome then
 			TextBackground(borderColor);
 
 		VideoColumns := columns;
 		if VideoMonochrome then begin
-			if LastMode in [0, 1, 2, 3] then begin
+			if VideoUseFastPath then
+				VideoWriteText := VideoWriteTextFastBW
+			else
+				VideoWriteText := VideoWriteTextCGABW;
+
+			if (LastMode >= 0) and (LastMode <= 3) then begin
 				if columns = 80 then begin
 					TextMode(BW80);
-					VideoWriteText := VideoWriteTextBW80;
 				end else begin
 					TextMode(BW40);
-					VideoWriteText := VideoWriteTextBW40;
 				end;
 			end else begin
-				VideoWriteText := VideoWriteTextBW80;
 				TextMode(7);
 				VideoColumns := 80;
 			end;
 		end else begin
+			if VideoUseFastPath then
+				VideoWriteText := VideoWriteTextFast
+			else
+				VideoWriteText := VideoWriteTextCGA;
+
 			if VideoColumns = 80 then begin
 				TextMode(CO80);
-				VideoWriteText := VideoWriteTextCO80;
 			end else begin
 				TextMode(CO40);
-				VideoWriteText := VideoWriteTextCO40;
 			end;
-			if not VideoMonochrome then
-				TextBackground(borderColor);
-			ClrScr;
+
+			TextBackground(borderColor);
 		end;
+
+		ClrScr;
+
 		if not VideoCursorVisible then
 			VideoHideCursor;
 		VideoSetBorderColor(borderColor);
@@ -412,9 +278,12 @@ procedure VideoUninstall;
 	var
 		regs: Registers;
 	begin
-		regs.AX := $1201;
-		regs.BL := $30;
-		Intr($10, regs);
+		if VideoEGAInstalled then begin
+			regs.AX := $1201;
+			regs.BL := $30;
+			Intr($10, regs);
+		end;
+
 		TextBackground(0);
 		VideoColumns := 80;
 		if VideoMonochrome then
@@ -457,7 +326,8 @@ procedure VideoMove(x, y, chars: integer; data: pointer; toVideo: boolean);
 		offset: integer;
 	begin
 		offset := (y * VideoColumns + x) * 2;
-		VideoWriteTextCO80(0, 0, 0, '');
+		if not VideoUseFastPath then
+			VideoWriteTextCGA(0, 0, 0, '');
 		if toVideo then
 			Move(data^, Ptr(VideoTextSegment, offset)^, chars * 2)
 		else
@@ -468,7 +338,7 @@ procedure VideoMove(x, y, chars: integer; data: pointer; toVideo: boolean);
 begin
 	VideoBorderColor := 0;
 	VideoColumns := 80;
-	VideoWriteText := VideoWriteTextBW80;
+	VideoWriteText := VideoWriteTextFastBW;
 	if LastMode = 7 then begin
 		VideoTextSegment := $B000;
 		VideoMonochrome := true;
@@ -478,4 +348,5 @@ begin
 	end;
 	VideoTextPointer := Ptr(VideoTextSegment, $0000);
 	VideoCursorVisible := true;
+	VideoUseFastPath := false;
 end.


### PR DESCRIPTION
This is one of the more important optimizations from ClassicZoo and - notably - it doesn't touch any of ZZT 3.2's game code.

This PR does the following:

* Optimizes drawing on CGA cards with a faster ASM routine.
* Optimizes drawing on EGA/VGA+ cards with a much faster ASM routine. The CGA routine, to avoid the "snow" effect, only draws the string provided to VideoWriteText (effectively, simplifying) once a new horizontal blank starts (which means it can draw at most a few hundred characters per frame). The EGA/VGA+ routine doesn't have to do that, so it doesn't.
* Walls off calling (some) EGA-only interrupts behind `VideoEGAInstalled`. This is probably not necessary, but is nice to do for compatibility.
* As a bonus, it fixes SetBlink() to work not just on EGA/VGA+ cards, but also older CGA ones.