### PR TITLE
Fix bug where the unpause movement is not taken into account for SPACE.

### DIFF
--- a/WEAVE_30/SRC_W30/GAME.PAS
+++ b/WEAVE_30/SRC_W30/GAME.PAS
@@ -2411,6 +2411,12 @@ procedure GamePlayLoop(boardChanged: boolean);
 					InputKeyPressed := #0;
 				end;
 
+				{ Fix bug where the unpause movement is not taken into account for SPACE. }
+				if (InputDeltaX <> 0) or (InputDeltaY <> 0) then begin
+					PlayerDirX := InputDeltaX;
+					PlayerDirY := InputDeltaY;
+				end;
+
 				if NoClip then begin
 					if (InputDeltaX <> 0) or (InputDeltaY <> 0) then begin
 						with Board.Stats[0] do begin


### PR DESCRIPTION
In ZZT 3.2, the first player movement (the one which unpauses the game on world start) is not taken into account for shooting with the SPACE key. This fixes that issue.

Found and requested by The Green Herring.